### PR TITLE
Fix for issues when using FFImageLoading control in an Intune managed…

### DIFF
--- a/source/FFImageLoading.Droid/Cache/ImageCache.cs
+++ b/source/FFImageLoading.Droid/Cache/ImageCache.cs
@@ -149,7 +149,7 @@ namespace FFImageLoading.Cache
 			if (percent < 0.01f || percent > 0.8f)
 				throw new Exception("GetCacheSizeInPercent - percent must be between 0.01 and 0.8 (inclusive)");
 
-			var context = Android.App.Application.Context.ApplicationContext;
+			var context = new Android.Content.ContextWrapper(Android.App.Application.Context);
 			var am = (ActivityManager) context.GetSystemService(Context.ActivityService);
 			bool largeHeap = (context.ApplicationInfo.Flags & ApplicationInfoFlags.LargeHeap) != 0;
 			int memoryClass = am.MemoryClass;

--- a/source/FFImageLoading.Droid/Work/ImageLoaderTask.cs
+++ b/source/FFImageLoading.Droid/Work/ImageLoaderTask.cs
@@ -95,7 +95,7 @@ namespace FFImageLoading.Work
 		{
 			get
 			{
-				return Android.App.Application.Context.ApplicationContext;
+				return new Android.Content.ContextWrapper(Android.App.Application.Context);
 			}
 		}
 

--- a/source/FFImageLoading.Droid/Work/StreamResolver/ApplicationBundleStreamResolver.cs
+++ b/source/FFImageLoading.Droid/Work/StreamResolver/ApplicationBundleStreamResolver.cs
@@ -14,7 +14,7 @@ namespace FFImageLoading.Work.StreamResolver
 
 		private Context Context {
 			get {
-				return Android.App.Application.Context.ApplicationContext;
+				return new Android.Content.ContextWrapper(Android.App.Application.Context);
 			}
 		}
 

--- a/source/FFImageLoading.Droid/Work/StreamResolver/CompiledResourceStreamResolver.cs
+++ b/source/FFImageLoading.Droid/Work/StreamResolver/CompiledResourceStreamResolver.cs
@@ -15,7 +15,7 @@ namespace FFImageLoading.Work.StreamResolver
 
 		private Context Context {
 			get {
-				return Android.App.Application.Context.ApplicationContext;
+				return new Android.Content.ContextWrapper(Android.App.Application.Context);
 			}
 		}
 


### PR DESCRIPTION
… Android Xamarin app. Context from Android.App.Application.Context.ApplicationContext is not fully loaded, most of the properties throws an JavaNullPointerException, causing the images to be empty on Android.

When using new Android.Content.ContextWrapper(Android.App.Application.Context) it works again.