### PR TITLE
fix for thread block

### DIFF
--- a/source/FFImageLoading.Touch/Helpers/ScaleHelper.cs
+++ b/source/FFImageLoading.Touch/Helpers/ScaleHelper.cs
@@ -1,28 +1,23 @@
 ﻿using System;
-using Foundation;
 using UIKit;
 
 namespace FFImageLoading.Helpers
 {
-	public static class ScaleHelper
-	{
-		private static readonly Lazy<nfloat> _scale = new Lazy<nfloat>(() =>
-		{
-            nfloat scale = 1;
+    public static class ScaleHelper
+    {
+        public static nfloat Scale
+        {
+            get;
+            private set;
+        }
+
+        public static void Init()
+        {
             MainThreadDispatcher.Instance.Post(() =>
             {
-                scale = UIScreen.MainScreen.Scale;
+               Scale = UIScreen.MainScreen.Scale;
             });
-            return scale;
-		});
-
-		public static nfloat Scale
-		{
-			get
-			{
-				return _scale.Value;
-			}
-		}
-	}
+        }
+    }
 }
 

--- a/source/FFImageLoading.Touch/Work/PlatformImageLoaderTask.cs
+++ b/source/FFImageLoading.Touch/Work/PlatformImageLoaderTask.cs
@@ -20,9 +20,7 @@ namespace FFImageLoading.Work
             : base(ImageCache.Instance, configuration.DataResolverFactory ?? DataResolvers.DataResolverFactory.Instance, target, parameters, imageService, configuration, mainThreadDispatcher, true)
         {
             // do not remove! Kicks scale retrieval so it's available for all, without deadlocks due to accessing MainThread
-            #pragma warning disable 0219
             ScaleHelper.Init();
-            #pragma warning restore 0219
         }
 
         protected override Task SetTargetAsync(UIImage image, bool animated)

--- a/source/FFImageLoading.Touch/Work/PlatformImageLoaderTask.cs
+++ b/source/FFImageLoading.Touch/Work/PlatformImageLoaderTask.cs
@@ -21,7 +21,7 @@ namespace FFImageLoading.Work
         {
             // do not remove! Kicks scale retrieval so it's available for all, without deadlocks due to accessing MainThread
             #pragma warning disable 0219
-            var ignore = ScaleHelper.Scale;
+            ScaleHelper.Init();
             #pragma warning restore 0219
         }
 


### PR DESCRIPTION
Not sure the exact technical reasons but "MainThreadDispatcher.Instance.Post" -> "DispatchQueue.MainQueue.DispatchSync(action)" was blocking when being called within the lazy load code. Bringing the code out of this into a method did the trick and the thread is no longer blocked.