### PR TITLE
Priority Bump on similar tasks

### DIFF
--- a/source/FFImageLoading.Common/Work/WorkScheduler.cs
+++ b/source/FFImageLoading.Common/Work/WorkScheduler.cs
@@ -235,6 +235,14 @@ namespace FFImageLoading.Work
                     Interlocked.Increment(ref _statsTotalPending);
                     PendingTasks.Add(currentPendingTask);
                 }
+                else
+                {
+                    if (task.Parameters.Priority > similarRunningTask.ImageLoadingTask.Parameters.Priority)
+                    {
+                        var similarIndex = PendingTasks.IndexOf(similarRunningTask);
+                        PendingTasks[similarIndex].ImageLoadingTask.Parameters.WithPriority((LoadingPriority)task.Parameters.Priority);
+                    }
+                }
             }
 
             if (PauseWork)


### PR DESCRIPTION
We should bump up the priority on pending tasks if similar tasks have a higher priority.