### PR TITLE
ScaleHelper is now only initialized once

### DIFF
--- a/source/FFImageLoading.Touch/Helpers/ScaleHelper.cs
+++ b/source/FFImageLoading.Touch/Helpers/ScaleHelper.cs
@@ -13,6 +13,9 @@ namespace FFImageLoading.Helpers
 
         public static void Init()
         {
+            if (Scale > 0)
+                return;
+
             MainThreadDispatcher.Instance.Post(() =>
             {
                Scale = UIScreen.MainScreen.Scale;


### PR DESCRIPTION
In iOS, every time we create a "PlatformImageLoaderTask" it is initialising the ScaleHelper. And for some reason the "Scale = UIScreen.MainScreen.Scale;" is blocking the main thread in certain situations. Because the scale won't change, we just need to initialize the ScaleHelper once.