### PR TITLE
OnSuccess, OnError, OnFinish always null

### DIFF
--- a/source/FFImageLoading.Cross/MvxImageLoadingView.cs
+++ b/source/FFImageLoading.Cross/MvxImageLoadingView.cs
@@ -153,7 +153,10 @@ namespace FFImageLoading.Cross
 			if (disposing)
 			{
 				CleanParameters();
-			}
+        OnSuccess = null;
+        OnError = null;
+        OnFinish = null;
+      }
 			base.Dispose(disposing);
 		}
 
@@ -164,9 +167,6 @@ namespace FFImageLoading.Cross
 				_parameters.Dispose();
 				_parameters = null;
 			}
-			OnSuccess = null;
-			OnError = null;
-			OnFinish = null;
 		}
 
 		private TaskParameter MakeParams()


### PR DESCRIPTION
CleanParameters called before the makings of params, which sets
OnSuccess, OnError, and OnFinish to null, those Actions should be
conserved and set to null on dispose