### PR TITLE
Fix for "Images don't show up in UWP release build"

### DIFF
--- a/source/FFImageLoading.Windows/Extensions/ImageExtensions.cs
+++ b/source/FFImageLoading.Windows/Extensions/ImageExtensions.cs
@@ -19,11 +19,16 @@ namespace FFImageLoading.Extensions
 
             WriteableBitmap writeableBitmap = null;
 
-            await MainThreadDispatcher.Instance.PostAsync(async () =>
+            var waitHandle = new AutoResetEvent(false);
+
+            MainThreadDispatcher.Instance.PostAsync(async () =>
             {
                 writeableBitmap = await holder.ToWriteableBitmap();
                 writeableBitmap.Invalidate();
+                waitHandle.Set();
             });
+
+            waitHandle.WaitOne(TimeSpan.FromSeconds(5));
 
             return writeableBitmap;
         }


### PR DESCRIPTION
This fixes the issues described in https://github.com/luberda-molinet/FFImageLoading/issues/508. The issues is that, at least in release mode, return writeableBitmap is called before the code in MainThreadDispatcher.Instance.PostAsync is finished. Await does not help. I have encountered this way way before in Windows Phone 8 times (http://dotnetbyexample.blogspot.nl/2013/04/windows-phone-8-navigation-part_29.html) and I tried the same fix. It feels like a kludge, but it's a kludge that works. I have spent _quite_ some time on my last project figuring this out ;)