### PR TITLE
Fix race condition in WorkScheduler

### DIFF
--- a/source/FFImageLoading.Common/Concurrency/FastPriorityQueue/SimplePriorityQueue.cs
+++ b/source/FFImageLoading.Common/Concurrency/FastPriorityQueue/SimplePriorityQueue.cs
@@ -110,6 +110,35 @@ namespace FFImageLoading.Concurrency
         }
 
         /// <summary>
+        /// Tries to remove the head of the queue
+        /// </summary>
+        /// <param name="item"><see cref="TItem"/></param>
+        /// <returns>If queue is empty <value>false</value>, else <value>true</value></returns>
+        public virtual bool TryDequeue(out TItem item)
+        {
+            lock (_queue)
+            {
+                if (_queue.Count < 1)
+                {
+                    item = default(TItem);
+                    return false;
+                }
+
+                try
+                {
+                    var node = _queue.Dequeue();
+                    item = node.Data;
+                    return true;
+                }
+                catch (InvalidOperationException)
+                {
+                    item = default(TItem);
+                    return false;
+                }
+            }
+        }
+
+        /// <summary>
         /// Enqueue a node to the priority queue.  Higher values are placed in front. Ties are broken by first-in-first-out.
         /// This queue automatically resizes itself, so there's no concern of the queue becoming 'full'.
         /// Duplicates are allowed.

--- a/source/FFImageLoading.Common/Work/WorkScheduler.cs
+++ b/source/FFImageLoading.Common/Work/WorkScheduler.cs
@@ -299,10 +299,8 @@ namespace FFImageLoading.Work
                 int numberOfTasks = MaxParallelTasks - RunningTasks.Count + Math.Min(preloadOrUrlTasksCount, MaxParallelTasks / 2);
                 tasksToRun = new Dictionary<string, IImageLoaderTask>();
 
-                while (tasksToRun.Count < numberOfTasks && PendingTasks.Count > 0)
+                while (tasksToRun.Count < numberOfTasks && PendingTasks.TryDequeue(out IImageLoaderTask task))
                 {
-                    var task = PendingTasks.Dequeue();
-
                     if (task == null || task.IsCancelled || task.IsCompleted)
                         continue;
 

--- a/source/FFImageLoading.Common/Work/WorkScheduler.cs
+++ b/source/FFImageLoading.Common/Work/WorkScheduler.cs
@@ -242,7 +242,11 @@ namespace FFImageLoading.Work
         {
             Task.Factory.StartNew(async () =>
             {
-                await TakeFromPendingTasksAndRunAsync().ConfigureAwait(false); // FMT: we limit concurrent work using MaxParallelTasks
+                try
+                {
+                    await TakeFromPendingTasksAndRunAsync().ConfigureAwait(false); // FMT: we limit concurrent work using MaxParallelTasks
+                }
+                catch { /* ignored on purpose */ }
             }, CancellationToken.None, TaskCreationOptions.DenyChildAttach | TaskCreationOptions.HideScheduler, TaskScheduler.Default).ConfigureAwait(false);
         }
 

--- a/source/Tests/FFImageLoading.Core.Tests/FFImageLoading/Concurrency/SimplePriorityQueue_Test.cs
+++ b/source/Tests/FFImageLoading.Core.Tests/FFImageLoading/Concurrency/SimplePriorityQueue_Test.cs
@@ -222,6 +222,32 @@ namespace FFImageLoading.Core.Tests.FFImageLoading.Concurrency
             }
         }
 
+        [Fact]
+        public void Given_item_trydequeued_Then_count_decreases()
+        {
+            var request = new Mock<IImageLoaderTask>().Object;
+            var sut = CreatePriorityQueue();
+            sut.Enqueue(request, 0);
+            sut.Enqueue(request, 0);
+            sut.Enqueue(request, 0);
+            var result = sut.TryDequeue(out IImageLoaderTask item);
+
+            Assert.True(result);
+            Assert.Equal(request, item);
+
+            Assert.Equal(2, sut.Count);
+        }
+
+        [Fact]
+        public void Given_queue_is_empty_trydequeue_returns_false()
+        {
+            var sut = CreatePriorityQueue();
+
+            var result = sut.TryDequeue(out IImageLoaderTask item);
+            Assert.True(!result);
+            Assert.Equal(default(IImageLoaderTask), item);
+        }
+
         private SimplePriorityQueue<IImageLoaderTask, int> CreatePriorityQueue()
         {
             var queue = new StubFixedSizePriorityQueue();


### PR DESCRIPTION
This potentially fixes the race condition in #655 and definitely eats the exception so apps won't crash if it occurs.