### PR TITLE
Add default value for FlipTransformation in Droid

### DIFF
--- a/source/FFImageLoading.Transformations.Droid/FlipTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/FlipTransformation.cs
@@ -8,6 +8,10 @@ namespace FFImageLoading.Transformations
 	[Preserve(AllMembers = true)]
 	public class FlipTransformation: TransformationBase
 	{
+		public FlipTransformation() : this(FlipType.Horizontal)
+		{
+		}
+		
 		public FlipTransformation(FlipType flipType)
 		{
 			FlipType = flipType;


### PR DESCRIPTION
I propose to have same contracts between all supported platforms. FlipTransformation iOS and Windows implementations have default constructors and this allows us to have simple XAMLs. So we may use the same pattern and set default FlipTransforamtion type to Horizontal for Android as well.