### PR TITLE
Fix Cannot access a disposed object crash in LruCache.SizeOf method

### DIFF
--- a/source/FFImageLoading.Droid/Cache/LRUCache.cs
+++ b/source/FFImageLoading.Droid/Cache/LRUCache.cs
@@ -15,7 +15,7 @@ namespace FFImageLoading.Cache
         {
             var drawable = value as ISelfDisposingBitmapDrawable;
 
-            if (drawable != null)
+            if (drawable != null && drawable.Handle.ToInt32() != 0)
                 return drawable.SizeInBytes;
 
             return 0;


### PR DESCRIPTION
Fix crash reported [here](https://github.com/luberda-molinet/FFImageLoading/issues/1020).