### PR TITLE
Hide preserveattribute annotation

### DIFF
--- a/source/FFImageLoading.Common/Helpers/PreserveAttribute.cs
+++ b/source/FFImageLoading.Common/Helpers/PreserveAttribute.cs
@@ -2,7 +2,7 @@
 
 namespace FFImageLoading
 {
-    public sealed class PreserveAttribute : System.Attribute
+    sealed class PreserveAttribute : System.Attribute
     {
         public bool AllMembers;
         public bool Conditional;

--- a/source/FFImageLoading.Common/Helpers/PreserveAttribute.cs
+++ b/source/FFImageLoading.Common/Helpers/PreserveAttribute.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("FFImageLoading.Transformations"),
-	InternalsVisibleTo("FFImageLoading.Svg.Forms"),
-	InternalsVisibleTo("FFImageLoading.Transformations")
-	]
+[assembly: InternalsVisibleTo("FFImageLoading.Transformations"), InternalsVisibleTo("FFImageLoading.Svg.Forms")]
 namespace FFImageLoading
 {
-    sealed class PreserveAttribute : System.Attribute
-    {
-        public bool AllMembers;
-        public bool Conditional;
-    }
+	sealed class PreserveAttribute : System.Attribute
+	{
+		public bool AllMembers;
+		public bool Conditional;
+	}
 }


### PR DESCRIPTION
Making annotation internal to avoid naming collision with existing annotation in namespace xamarin.forms.internals

![preserveattr](https://user-images.githubusercontent.com/1595367/42310379-91292dea-803b-11e8-830c-492f0883a1ed.PNG)
