### PR TITLE
Fix fill, clip-path and add gradientTransform

### DIFF
--- a/source/FFImageLoading.Svg.Shared/SKLinearGradient.cs
+++ b/source/FFImageLoading.Svg.Shared/SKLinearGradient.cs
@@ -5,7 +5,7 @@ namespace FFImageLoading.Svg.Platform
 {
     internal struct SKLinearGradient
     {
-        public SKLinearGradient(float startX, float startY, float endX, float endY, float[] positions, SKColor[] colors, SKShaderTileMode tileMode)
+        public SKLinearGradient(float startX, float startY, float endX, float endY, float[] positions, SKColor[] colors, SKShaderTileMode tileMode, SKMatrix gradientTransform)
         {
             StartX = startX;
             StartY = startY;
@@ -14,6 +14,7 @@ namespace FFImageLoading.Svg.Platform
             Positions = positions;
             Colors = colors;
             TileMode = tileMode;
+	        GradientTransform = gradientTransform;
         }
 
         public float StartX { get; set; }
@@ -29,6 +30,8 @@ namespace FFImageLoading.Svg.Platform
         public SKColor[] Colors { get; set; }
 
         public SKShaderTileMode TileMode { get; set; }
+
+	    public SKMatrix GradientTransform { get; set; }
 
         public SKPoint GetStartPoint(float x, float y, float width, float height)
         {

--- a/source/FFImageLoading.Svg.Shared/SKRadialGradient.cs
+++ b/source/FFImageLoading.Svg.Shared/SKRadialGradient.cs
@@ -5,7 +5,7 @@ namespace FFImageLoading.Svg.Platform
 {
     internal struct SKRadialGradient
     {
-        public SKRadialGradient(float centerX, float centerY, float radius, float[] positions, SKColor[] colors, SKShaderTileMode tileMode)
+        public SKRadialGradient(float centerX, float centerY, float radius, float[] positions, SKColor[] colors, SKShaderTileMode tileMode, SKMatrix gradientTransform)
         {
             CenterX = centerX;
             CenterY = centerY;
@@ -13,6 +13,7 @@ namespace FFImageLoading.Svg.Platform
             Positions = positions;
             Colors = colors;
             TileMode = tileMode;
+	        GradientTransform = gradientTransform;
         }
 
         public float CenterX { get; set; }
@@ -26,6 +27,8 @@ namespace FFImageLoading.Svg.Platform
         public SKColor[] Colors { get; set; }
 
         public SKShaderTileMode TileMode { get; set; }
+
+	    public SKMatrix GradientTransform { get; set; }
 
         public SKPoint GetCenterPoint(float x, float y, float width, float height)
         {

--- a/source/FFImageLoading.Svg.Shared/SkSvg.cs
+++ b/source/FFImageLoading.Svg.Shared/SkSvg.cs
@@ -152,14 +152,18 @@ namespace FFImageLoading.Svg.Platform
             var ns = svg.Name.Namespace;
 
             // find the defs (gradients) - and follow all hrefs
-            foreach (var d in svg.Descendants())
-            {
-                var id = ReadId(d);
-                if (!string.IsNullOrEmpty(id))
-                    defs[id] = ReadDefinition(d);
-            }
+	        var defsE = svg.Descendants().FirstOrDefault(x => x.Name.LocalName == "defs");
+	        if (defsE != null)
+	        {
+		        foreach (var d in defsE.Descendants())
+		        {
+			        var id = ReadId(d);
+			        if (!string.IsNullOrEmpty(id))
+				        defs[id] = ReadDefinition(d);
+		        }
+	        }
 
-            ReadDefsStyles(svg);
+	        ReadDefsStyles(svg);
 
             Version = svg.Attribute("version")?.Value;
             Title = svg.Element(ns + "title")?.Value;

--- a/source/FFImageLoading.Svg.Shared/SkSvg.cs
+++ b/source/FFImageLoading.Svg.Shared/SkSvg.cs
@@ -391,7 +391,8 @@ namespace FFImageLoading.Svg.Platform
                                 var endPoint = gradient.GetEndPoint(x, y, width, height);
 
                                 using (var gradientShader = SKShader.CreateLinearGradient(
-                                    startPoint, endPoint, gradient.Colors, gradient.Positions, gradient.TileMode))
+                                    startPoint, endPoint, gradient.Colors, gradient.Positions, gradient.TileMode,
+	                                gradient.GradientTransform))
                                 {
                                     var oldColor = fill.Color;
                                     var oldShader = fill.Shader;
@@ -409,7 +410,8 @@ namespace FFImageLoading.Svg.Platform
                                 var radius = gradient.GetRadius(width, height);
 
                                 using (var gradientShader = SKShader.CreateRadialGradient(
-                                    centerPoint, radius, gradient.Colors, gradient.Positions, gradient.TileMode))
+                                    centerPoint, radius, gradient.Colors, gradient.Positions, gradient.TileMode,
+                                    gradient.GradientTransform))
                                 {
                                     var oldColor = fill.Color;
                                     var oldShader = fill.Shader;
@@ -1421,10 +1423,11 @@ namespace FFImageLoading.Svg.Platform
             var tileMode = ReadSpreadMethod(e);
             var stops = ReadStops(e);
 
-            // TODO: check gradientTransform attribute
+	        var transform = ReadTransform(e.Attribute("gradientTransform")?.Value ?? string.Empty);
+
             // TODO: use absolute
 
-            return new SKRadialGradient(centerX, centerY, radius, stops.Keys.ToArray(), stops.Values.ToArray(), tileMode);
+            return new SKRadialGradient(centerX, centerY, radius, stops.Keys.ToArray(), stops.Values.ToArray(), tileMode, transform);
         }
 
         private SKLinearGradient ReadLinearGradient(XElement e)
@@ -1441,10 +1444,11 @@ namespace FFImageLoading.Svg.Platform
             var tileMode = ReadSpreadMethod(e);
             var stops = ReadStops(e);
 
-            // TODO: check gradientTransform attribute
-            // TODO: use absolute
+            var transform = ReadTransform(e.Attribute("gradientTransform")?.Value ?? string.Empty);
 
-            return new SKLinearGradient(startX, startY, endX, endY, stops.Keys.ToArray(), stops.Values.ToArray(), tileMode);
+	        // TODO: use absolute
+
+            return new SKLinearGradient(startX, startY, endX, endY, stops.Keys.ToArray(), stops.Values.ToArray(), tileMode, transform);
         }
 
         private static SKShaderTileMode ReadSpreadMethod(XElement e)

--- a/source/FFImageLoading.Svg.Shared/SkSvg.cs
+++ b/source/FFImageLoading.Svg.Shared/SkSvg.cs
@@ -277,10 +277,15 @@ namespace FFImageLoading.Svg.Platform
             if (GetString(style, "display") == "none")
                 return;
 
-            // transform matrix
-            var transform = ReadTransform(e.Attribute("transform")?.Value ?? string.Empty);
             canvas.Save();
-            canvas.Concat(ref transform);
+
+	        // transform matrix
+	        var transformValue = e.Attribute("transform")?.Value;
+	        if (String.IsNullOrEmpty(transformValue))
+	        {
+		        var transform = ReadTransform(transformValue);
+		        canvas.Concat(ref transform);
+	        }
 
 	        // clip-path - can be an attribute or css
             var clipPath = ReadClipPath(GetString(style, "clip-path"));

--- a/source/FFImageLoading.Svg.Shared/SkSvg.cs
+++ b/source/FFImageLoading.Svg.Shared/SkSvg.cs
@@ -278,8 +278,8 @@ namespace FFImageLoading.Svg.Platform
             canvas.Save();
             canvas.Concat(ref transform);
 
-            // clip-path
-            var clipPath = ReadClipPath(e.Attribute("clip-path")?.Value ?? string.Empty);
+	        // clip-path - can be an attribute or css
+            var clipPath = ReadClipPath(GetString(style, "clip-path"));
             if (clipPath != null)
             {
                 canvas.ClipPath(clipPath);

--- a/source/FFImageLoading.Svg.Shared/SkSvg.cs
+++ b/source/FFImageLoading.Svg.Shared/SkSvg.cs
@@ -351,7 +351,7 @@ namespace FFImageLoading.Svg.Platform
                             return;
                         }
 
-                        string fillId = e.Attribute("fill")?.Value;
+	                    string fillId = GetString(style, "fill");
                         if (!string.IsNullOrWhiteSpace(fillId) && fills.TryGetValue(fillId, out object addFill))
                         {
                             var x = ReadNumber(e.Attribute("x"));

--- a/source/FFImageLoading.Svg.Shared/SkSvg.cs
+++ b/source/FFImageLoading.Svg.Shared/SkSvg.cs
@@ -274,7 +274,7 @@ namespace FFImageLoading.Svg.Platform
             // read style
             var style = ReadPaints(e, ref stroke, ref fill, isGroup);
 
-            if (style.TryGetValue("display", out var displayValue) && displayValue == "none")
+            if (GetString(style, "display") == "none")
                 return;
 
             // transform matrix
@@ -381,7 +381,7 @@ namespace FFImageLoading.Svg.Platform
 
                             if (!(width > 0f && height > 0f))
                             {
-                                var root = e?.Document?.Root;
+                                var root = e.Document?.Root;
                                 width = ReadNumber(root?.Attribute("width"));
                                 height = ReadNumber(root?.Attribute("height"));
                             }


### PR DESCRIPTION
The fill property is parsed from style but at rendering only the attribute was checked. Now it will consider both.
The clip-path property was only parsed if specified as an attribute. Now it will consider the attribute and style.
Gradients ignored the gradientTransform property which made some gradients render incorrectly. I added support to read it and apply it. However support for gradientUnits is still missing.

Some other minor syntax changes were also made. 
