### PR TITLE
Revert Droid TargetFrameworkVersion to v8.1

### DIFF
--- a/source/FFImageLoading.Droid/FFImageLoading.Droid.csproj
+++ b/source/FFImageLoading.Droid/FFImageLoading.Droid.csproj
@@ -11,7 +11,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AssemblyName>FFImageLoading.Platform</AssemblyName>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.1.99</TargetFrameworkVersion>
     <NoWarn>1701;1702;1705;1591;1587;NU1605;NU1605</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/source/FFImageLoading.Droid/FFImageLoading.Droid.csproj
+++ b/source/FFImageLoading.Droid/FFImageLoading.Droid.csproj
@@ -11,7 +11,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AssemblyName>FFImageLoading.Platform</AssemblyName>
-    <TargetFrameworkVersion>v8.1.99</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <NoWarn>1701;1702;1705;1591;1587;NU1605;NU1605</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/source/FFImageLoading.Forms.Droid/FFImageLoading.Forms.Droid.csproj
+++ b/source/FFImageLoading.Forms.Droid/FFImageLoading.Forms.Droid.csproj
@@ -12,7 +12,7 @@
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <AndroidResgenClass>Resource</AndroidResgenClass>
     <AssemblyName>FFImageLoading.Forms.Platform</AssemblyName>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v8.1</TargetFrameworkVersion>
     <AndroidTlsProvider></AndroidTlsProvider>
     <NoWarn>1701;1702;1705;1591;1587;NU1605</NoWarn>
   </PropertyGroup>


### PR DESCRIPTION
Seems that this was mistakenly bumped to 9.0 prematurely, and is causing compiler warnings.