### PR TITLE
Enforce clipping on fast renderer when using AspectFill.

### DIFF
--- a/source/FFImageLoading.Forms.Droid/CachedImageFastRenderer.cs
+++ b/source/FFImageLoading.Forms.Droid/CachedImageFastRenderer.cs
@@ -17,6 +17,7 @@ using FFImageLoading.Views;
 using Android.Views;
 using System.Reflection;
 using Android.Content;
+using Android.OS;
 using AView = Android.Views.View;
 
 namespace FFImageLoading.Forms.Platform
@@ -229,7 +230,11 @@ namespace FFImageLoading.Forms.Platform
         protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
         {
             base.OnLayout(changed, left, top, right, bottom);
-            ClipBounds = GetScaleType() == ScaleType.CenterCrop ? new Rect(0, 0, right - left, bottom - top) : null;
+
+            if ((int)Build.VERSION.SdkInt >= 18)
+            {
+                ClipBounds = GetScaleType() == ScaleType.CenterCrop ? new Rect(0, 0, right - left, bottom - top) : null;
+            }                
         }
 
         void UpdateAspect()

--- a/source/FFImageLoading.Forms.Droid/CachedImageFastRenderer.cs
+++ b/source/FFImageLoading.Forms.Droid/CachedImageFastRenderer.cs
@@ -226,6 +226,12 @@ namespace FFImageLoading.Forms.Platform
             ElementPropertyChanged?.Invoke(this, e);
         }   
 
+        protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
+        {
+            base.OnLayout(changed, left, top, right, bottom);
+            ClipBounds = GetScaleType() == ScaleType.CenterCrop ? new Rect(0, 0, right - left, bottom - top) : null;
+        }
+
         void UpdateAspect()
         {
             if (Control == null || Control.Handle == IntPtr.Zero || TypedElement == null || _isDisposed)


### PR DESCRIPTION
This change adds clipping to the boundaries of the `ImageView` when the ScaleType is set to `CENTER_CROP`.

Fixes #1086, #1148.
Already fixed in Xamarin.Forms for the `Image` fast renderer.
https://github.com/xamarin/Xamarin.Forms/pull/4218