### PR TITLE
Correct jpeg stream quality on iOS

### DIFF
--- a/source/FFImageLoading.Shared.IosMac/Extensions/PImageExtensions.cs
+++ b/source/FFImageLoading.Shared.IosMac/Extensions/PImageExtensions.cs
@@ -89,7 +89,7 @@ namespace FFImageLoading.Extensions
         public static System.IO.Stream AsJpegStream(this PImage image, int quality = 80)
         {
 #if __IOS__
-            return image.AsJPEG((nfloat)quality).AsStream();
+            return image.AsJPEG(quality / 100f).AsStream();
 #elif __MACOS__
             // todo: jpeg quality?
             var imageRep = new NSBitmapImageRep(image.AsTiff());


### PR DESCRIPTION
Correct the compression quality value on iOS platform

"The compression quality to use, 0.0 is the maximum compression (worse quality), and 1.0 minimum compression (best quality)"

from: 

https://docs.microsoft.com/en-us/dotnet/api/uikit.uiimage.asjpeg?view=xamarin-ios-sdk-12#UIKit_UIImage_AsJPEG_System_nfloat_