### PR TITLE
Fix clean on SimpleDiskCache

### DIFF
--- a/source/FFImageLoading.Shared/Cache/SimpleDiskCache.cs
+++ b/source/FFImageLoading.Shared/Cache/SimpleDiskCache.cs
@@ -240,8 +240,8 @@ namespace FFImageLoading.Cache
                 {
                     try
                     {
-                        Logger.Debug(string.Format("SimpleDiskCache: Removing expired file {0}", kvp.Key));
-                        File.Delete(Path.Combine(_cachePath, kvp.Key));
+                        Logger.Debug(string.Format("SimpleDiskCache: Removing expired file {0}", oldCacheEntry.FileName));
+                        File.Delete(Path.Combine(_cachePath, oldCacheEntry.FileName));
                     }
                     // Analysis disable once EmptyGeneralCatchClause
                     catch

--- a/source/FFImageLoading.Windows/Cache/SimpleDiskCache.cs
+++ b/source/FFImageLoading.Windows/Cache/SimpleDiskCache.cs
@@ -127,7 +127,7 @@ namespace FFImageLoading.Cache
                 {
                     try
                     {
-                        Logger.Debug(string.Format("SimpleDiskCache: Removing expired file {0}", kvp.Key));
+                        Logger.Debug(string.Format("SimpleDiskCache: Removing expired file {0}", oldCacheEntry.FileName));
                         var file = await cacheFolder.GetFileAsync(oldCacheEntry.FileName);
                         await file.DeleteAsync();
                     }


### PR DESCRIPTION
Delete the correct file when starting the SimpleDiskCache used on iOS / Android. Probably helps with the cache growing size (#500)