### PR TITLE
MvxCachedImageView : Set DataResolvers Independently

### DIFF
--- a/source/FFImageLoading.Cross/MvxCachedImageView.cs
+++ b/source/FFImageLoading.Cross/MvxCachedImageView.cs
@@ -362,7 +362,15 @@ namespace FFImageLoading.Cross
 			if (CustomDataResolver != null)
 			{
 				imageLoader.WithCustomDataResolver(CustomDataResolver);
+			}
+
+			if (CustomLoadingPlaceholderDataResolver != null)
+			{
 				imageLoader.WithCustomLoadingPlaceholderDataResolver(CustomLoadingPlaceholderDataResolver);
+			}
+
+			if (CustomErrorPlaceholderDataResolver != null)
+			{
 				imageLoader.WithCustomErrorPlaceholderDataResolver(CustomErrorPlaceholderDataResolver);
 			}
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Feature

### :arrow_heading_down: What is the current behavior?
Users have to set `CustomDataResolver` to have working `CustomLoadingPlaceholderDataResolver` and `CustomErrorPlaceholderDataResolver`.

### :new: What is the new behavior (if this is a feature change)?
Users can set these data resolvers independently.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
None

### :memo: Links to relevant issues/docs
#1361

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop