### PR TITLE
[Tizen] Remove all interop call to the native libs

### DIFF
--- a/samples/Simple.TizenForms.Sample/Simple.TizenForms.Sample.cs
+++ b/samples/Simple.TizenForms.Sample/Simple.TizenForms.Sample.cs
@@ -30,7 +30,7 @@ namespace Simple.TizenForms.Sample
         static void Main(string[] args)
         {
             var app = new Program();
-            FFImageLoading.Forms.Tizen.CachedImageRenderer.Init(app);
+            FFImageLoading.Forms.Platform.CachedImageRenderer.Init(app);
             Xamarin.Forms.Platform.Tizen.Forms.Init(app, true);
             app.Run(args);
         }

--- a/samples/Simple.TizenForms.Sample/Simple.TizenForms.Sample.csproj
+++ b/samples/Simple.TizenForms.Sample/Simple.TizenForms.Sample.csproj
@@ -1,17 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Tizen.NET.Sdk/1.0.5">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen40</TargetFramework>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="5.0.0.14629">
-      <ExcludeAssets>Runtime</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
-    <PackageReference Include="Xamarin.Forms.Platform.Tizen" Version="2.5.1.444934" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\source\FFImageLoading.Common\FFImageLoading.csproj" />

--- a/source/FFImageLoading.Tizen/Decoders/BaseDecoder.cs
+++ b/source/FFImageLoading.Tizen/Decoders/BaseDecoder.cs
@@ -55,7 +55,7 @@ namespace FFImageLoading.Decoders
                         imageInformation.SetCurrentSize(
                             (int)((double)img.Size.Width / scaleDownFactor),
                             (int)((double)img.Size.Height / scaleDownFactor));
-                        EvasInterop.evas_object_image_load_scale_down_set(img.RealHandle, scaleDownFactor);
+                        img.SetScaleDown(scaleDownFactor);
                     }
                 }
 

--- a/source/FFImageLoading.Tizen/Views/EvasImageContainer.cs
+++ b/source/FFImageLoading.Tizen/Views/EvasImageContainer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using ElmSharp;
 using AppFW = Tizen.Applications;
@@ -86,7 +85,7 @@ namespace FFImageLoading.Views
             var file = Path.Combine(absPath, filename);
 
             // Readme : I can't know, EFL "evas_object_image_save" was safty for multithread, So, i did't run on worker-thread
-            evas_object_image_save(Source.RealHandle, file, null, flags);
+            Source.Save(file, null, flags);
 
             TaskCompletionSource<byte[]> tcs = new TaskCompletionSource<byte[]>();
             Task.Run(() =>
@@ -180,8 +179,5 @@ namespace FFImageLoading.Views
             }
             _content.Geometry = contentBound;
         }
-
-        [DllImport("libevas.so.1")]
-        internal static extern void evas_object_image_save(IntPtr obj, string file, string key, string flags);
     }
 }

--- a/source/FFImageLoading.Tizen/Views/SharedEvasImage.cs
+++ b/source/FFImageLoading.Tizen/Views/SharedEvasImage.cs
@@ -1,4 +1,5 @@
-﻿using ElmSharp;
+﻿using System.Reflection;
+using ElmSharp;
 
 namespace FFImageLoading.Views
 {
@@ -44,6 +45,30 @@ namespace FFImageLoading.Views
                     image.Unrealize();
                 });
             }
+        }
+    }
+
+    internal static class EvasImageEx
+    {
+        public static void SetScaleDown(this EvasImage evasImage, int scale)
+        {
+            var interop = typeof(EvasObject).Assembly.GetType("Interop");
+            var elementary = interop?.GetNestedType("Elementary", BindingFlags.NonPublic | BindingFlags.Static) ?? null;
+            var method = elementary?.GetMethod("evas_object_image_load_scale_down_set", BindingFlags.NonPublic | BindingFlags.Static);
+            if (method != null)
+            {
+                method.Invoke(null, new object[] { evasImage.RealHandle, scale });
+            }
+            else
+            {
+                System.Console.WriteLine("No API evas_object_image_load_scale_down_set");
+            }
+        }
+
+
+        public static void Save(this EvasImage evasImage, string file, string key, string flags)
+        {
+            typeof(EvasImage)?.GetMethod("Save")?.Invoke(evasImage, new[] { file, key, flags });
         }
     }
 }

--- a/source/FFImageLoading.Tizen/Work/PlatformImageLoaderTask.cs
+++ b/source/FFImageLoading.Tizen/Work/PlatformImageLoaderTask.cs
@@ -99,10 +99,4 @@ namespace FFImageLoading.Work
             }
         }
     }
-
-    static class EvasInterop
-    {
-        [DllImport("libevas.so.1")]
-        internal static extern void evas_object_image_load_scale_down_set(IntPtr obj, int scale);
-    }
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
 * Remove all interop call to the native libs
 Fix : https://github.com/luberda-molinet/FFImageLoading/issues/1388


### :arrow_heading_down: What is the current behavior?
 * Some Tizen devices was not allow interop call to the  builtins native libs, so can't run on these device

### :new: What is the new behavior (if this is a feature change)?
 * Remove All interop call, so can run on all tizen devices, but some version of tizen does not support Downsample feature

### :boom: Does this PR introduce a breaking change?
 No

### :bug: Recommendations for testing
 No

### :memo: Links to relevant issues/docs
 Fix : https://github.com/luberda-molinet/FFImageLoading/issues/1388

### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
