### PR TITLE
Add width and height in percent handeling for ReadImage

### DIFF
--- a/source/FFImageLoading.Svg.Shared/SkSvg.cs
+++ b/source/FFImageLoading.Svg.Shared/SkSvg.cs
@@ -308,7 +308,7 @@ namespace FFImageLoading.Svg.Platform
 				{
 					case "image":
 						{
-							var image = ReadImage(e);
+							var image = ReadImage(e, canvas.DeviceClipBounds);
 							if (image.Bytes != null)
 							{
 								using (var bitmap = SKBitmap.Decode(image.Bytes))
@@ -490,10 +490,22 @@ namespace FFImageLoading.Svg.Platform
 			}
 		}
 
-		private SKSvgImage ReadImage(XElement e)
+		private SKSvgImage ReadImage(XElement e, SKRect sKRect)
 		{
 			var width = ReadNumber(e.Attribute("width"));
 			var height = ReadNumber(e.Attribute("height"));
+			if(e.Attribute("width")?.Value?.Contains("%") == true)
+			{
+				width = ReadNumber(e.Attribute("width")?.Value.Replace("%", ""));
+				width = sKRect.Width * (width / 100.0f);
+			}
+
+			if (e.Attribute("height")?.Value?.Contains("%") == true)
+			{
+				height = ReadNumber(e.Attribute("height")?.Value.Replace("%", ""));
+				height = sKRect.Height * (height / 100.0f);
+			}
+
 			var rect = SKRect.Create(width, height);
 
 			byte[] bytes = null;


### PR DESCRIPTION
I had a problem with the size of the embedded `data:image/png;base64` in SkSVG where the size is `100%` and not `pixel`.
