### PR TITLE
Add support to repeated/grouped CSS styles

### DIFF
--- a/source/FFImageLoading.Svg.Shared/Helpers/CssHelpers.cs
+++ b/source/FFImageLoading.Svg.Shared/Helpers/CssHelpers.cs
@@ -26,9 +26,26 @@ namespace FFImageLoading.Svg.Platform
 
             foreach (var item in items)
             {
-                destination.Add(item.Key, item.Value);
+                destination.AddOrUpdate(item.Key, item.Value);
             }
         }
+		
+		static void AddOrUpdate(this Dictionary<string,string> source, string key, string value)
+		{
+			if(value == null) 
+			{
+				return;
+			}
+			
+			if(source.ContainsKey(key))
+			{
+				source[key] += value;
+			}
+			else
+			{
+				source.Add(key, value);
+			}
+		}
 
         static string Minify(this string css) => Regex.Replace(css, @"(\r\n|\r|\n)", string.Empty).Trim();
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix to deal with duplicated/grouped styles in SVG images

### :arrow_heading_down: What is the current behavior?
If duplicated keys are found, the execution will throw a "DuplicatedKeyFoundException"

### :new: What is the new behavior (if this is a feature change)?
SVG image files with duplicated/grouped style keys are supported now

### :boom: Does this PR introduce a breaking change?
Nor breaking change. Just biggger support to SVG images

### :bug: Recommendations for testing
Try to load a svg that has duplicated/grouped CSS styles

### :memo: Links to relevant issues/docs
#1455 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
