### PR TITLE
Update MvxCachedImageView.cs

### DIFF
--- a/source/FFImageLoading.Windows/Views/MvxCachedImageView.cs
+++ b/source/FFImageLoading.Windows/Views/MvxCachedImageView.cs
@@ -131,7 +131,7 @@ namespace FFImageLoading.Views
         public static readonly DependencyProperty TransformationsProperty = DependencyProperty.Register(nameof(Transformations), typeof(bool), typeof(MvxCachedImageView), new PropertyMetadata(new List<ITransformation>(), OnTransformationsChanged));
 
         public IDataResolver CustomDataResolver { get { return (IDataResolver)GetValue(CustomDataResolverProperty); } set { SetValue(CustomDataResolverProperty, value); } }
-        public static readonly DependencyProperty CustomDataResolverProperty = DependencyProperty.Register(nameof(CustomDataResolver), typeof(bool), typeof(MvxCachedImageView), new PropertyMetadata(default(IDataResolver)));
+        public static readonly DependencyProperty CustomDataResolverProperty = DependencyProperty.Register(nameof(CustomDataResolver), typeof(IDataResolver), typeof(MvxCachedImageView), new PropertyMetadata(default(IDataResolver)));
 
         public IDataResolver CustomLoadingPlaceholderDataResolver { get { return (IDataResolver)GetValue(CustomLoadingPlaceholderDataResolverProperty); } set { SetValue(CustomLoadingPlaceholderDataResolverProperty, value); } }
         public static readonly DependencyProperty CustomLoadingPlaceholderDataResolverProperty = DependencyProperty.Register(nameof(CustomLoadingPlaceholderDataResolver), typeof(bool), typeof(MvxCachedImageView), new PropertyMetadata(default(IDataResolver)));

--- a/source/FFImageLoading.Windows/Views/MvxCachedImageView.cs
+++ b/source/FFImageLoading.Windows/Views/MvxCachedImageView.cs
@@ -101,10 +101,10 @@ namespace FFImageLoading.Views
         public static readonly DependencyProperty DownsampleUseDipUnitsProperty = DependencyProperty.Register(nameof(DownsampleUseDipUnits), typeof(bool), typeof(MvxCachedImageView), new PropertyMetadata(default(bool)));
 
         public TimeSpan? CacheDuration { get { return (TimeSpan?)GetValue(CacheDurationProperty); } set { SetValue(CacheDurationProperty, value); } }
-        public static readonly DependencyProperty CacheDurationProperty = DependencyProperty.Register(nameof(CacheDuration), typeof(bool), typeof(MvxCachedImageView), new PropertyMetadata(default(TimeSpan?)));
+        public static readonly DependencyProperty CacheDurationProperty = DependencyProperty.Register(nameof(CacheDuration), typeof(TimeSpan?), typeof(MvxCachedImageView), new PropertyMetadata(default(TimeSpan?)));
 
         public LoadingPriority LoadingPriority { get { return (LoadingPriority)GetValue(LoadingPriorityProperty); } set { SetValue(LoadingPriorityProperty, value); } }
-        public static readonly DependencyProperty LoadingPriorityProperty = DependencyProperty.Register(nameof(LoadingPriority), typeof(bool), typeof(MvxCachedImageView), new PropertyMetadata(default(LoadingPriority)));
+        public static readonly DependencyProperty LoadingPriorityProperty = DependencyProperty.Register(nameof(LoadingPriority), typeof(LoadingPriority), typeof(MvxCachedImageView), new PropertyMetadata(default(LoadingPriority)));
 
         public bool? BitmapOptimizations { get { return (bool?)GetValue(BitmapOptimizationsProperty); } set { SetValue(BitmapOptimizationsProperty, value); } }
         public static readonly DependencyProperty BitmapOptimizationsProperty = DependencyProperty.Register(nameof(BitmapOptimizations), typeof(bool?), typeof(MvxCachedImageView), new PropertyMetadata(default(bool?)));
@@ -125,19 +125,19 @@ namespace FFImageLoading.Views
         public static readonly DependencyProperty TransformPlaceholdersProperty = DependencyProperty.Register(nameof(TransformPlaceholders), typeof(bool), typeof(MvxCachedImageView), new PropertyMetadata(default(bool?)));
 
         public CacheType? CacheType { get { return (CacheType?)GetValue(CacheTypeProperty); } set { SetValue(CacheTypeProperty, value); } }
-        public static readonly DependencyProperty CacheTypeProperty = DependencyProperty.Register(nameof(CacheType), typeof(bool), typeof(MvxCachedImageView), new PropertyMetadata(default(CacheType?)));
+        public static readonly DependencyProperty CacheTypeProperty = DependencyProperty.Register(nameof(CacheType), typeof(CacheType?), typeof(MvxCachedImageView), new PropertyMetadata(default(CacheType?)));
 
         public List<ITransformation> Transformations { get { return (List<ITransformation>)GetValue(TransformationsProperty); } set { SetValue(TransformationsProperty, value); } }
-        public static readonly DependencyProperty TransformationsProperty = DependencyProperty.Register(nameof(Transformations), typeof(bool), typeof(MvxCachedImageView), new PropertyMetadata(new List<ITransformation>(), OnTransformationsChanged));
+        public static readonly DependencyProperty TransformationsProperty = DependencyProperty.Register(nameof(Transformations), typeof(List<ITransformation>), typeof(MvxCachedImageView), new PropertyMetadata(new List<ITransformation>(), OnTransformationsChanged));
 
         public IDataResolver CustomDataResolver { get { return (IDataResolver)GetValue(CustomDataResolverProperty); } set { SetValue(CustomDataResolverProperty, value); } }
         public static readonly DependencyProperty CustomDataResolverProperty = DependencyProperty.Register(nameof(CustomDataResolver), typeof(IDataResolver), typeof(MvxCachedImageView), new PropertyMetadata(default(IDataResolver)));
 
         public IDataResolver CustomLoadingPlaceholderDataResolver { get { return (IDataResolver)GetValue(CustomLoadingPlaceholderDataResolverProperty); } set { SetValue(CustomLoadingPlaceholderDataResolverProperty, value); } }
-        public static readonly DependencyProperty CustomLoadingPlaceholderDataResolverProperty = DependencyProperty.Register(nameof(CustomLoadingPlaceholderDataResolver), typeof(bool), typeof(MvxCachedImageView), new PropertyMetadata(default(IDataResolver)));
+        public static readonly DependencyProperty CustomLoadingPlaceholderDataResolverProperty = DependencyProperty.Register(nameof(CustomLoadingPlaceholderDataResolver), typeof(IDataResolver), typeof(MvxCachedImageView), new PropertyMetadata(default(IDataResolver)));
 
         public IDataResolver CustomErrorPlaceholderDataResolver { get { return (IDataResolver)GetValue(CustomErrorPlaceholderDataResolverProperty); } set { SetValue(CustomErrorPlaceholderDataResolverProperty, value); } }
-        public static readonly DependencyProperty CustomErrorPlaceholderDataResolverProperty = DependencyProperty.Register(nameof(CustomErrorPlaceholderDataResolver), typeof(bool), typeof(MvxCachedImageView), new PropertyMetadata(default(IDataResolver)));
+        public static readonly DependencyProperty CustomErrorPlaceholderDataResolverProperty = DependencyProperty.Register(nameof(CustomErrorPlaceholderDataResolver), typeof(IDataResolver), typeof(MvxCachedImageView), new PropertyMetadata(default(IDataResolver)));
 
         public string LoadingPlaceholderImagePath { get { return (string)GetValue(LoadingPlaceholderImagePathProperty); } set { SetValue(LoadingPlaceholderImagePathProperty, value); } }
         public static readonly DependencyProperty LoadingPlaceholderImagePathProperty = DependencyProperty.Register(nameof(LoadingPlaceholderImagePath), typeof(string), typeof(MvxCachedImageView), new PropertyMetadata(default(string)));


### PR DESCRIPTION
Fix incorrectly registered DependencyProperty type

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
fix

### :arrow_heading_down: What is the current behavior?
using MvxCachedImageView throws an exception, stating that the type Bool is not a IDataResolver

### :new: What is the new behavior (if this is a feature change)?
This exception won't be thrown anymore.

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing
Just use as normal

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ X ] All projects build
- [ X ] Follows style guide lines 
- [ X ] Relevant documentation was updated
- [ X ] Rebased onto current develop
